### PR TITLE
Improve handle_common.sh portability

### DIFF
--- a/direct/handle_common.sh
+++ b/direct/handle_common.sh
@@ -25,7 +25,7 @@ YAFFS_COMMON_SOURCES="\
 if [ "$1" = "copy" ] ; then
 set -e -x
 	for i in $YAFFS_COMMON_SOURCES ; do
-		sed ../$i \
+		sed \
 		-e "s/strcat/yaffs_strcat/g" \
 		-e "s/strcpy/yaffs_strcpy/g" \
 		-e "s/strncpy/yaffs_strncpy/g" \
@@ -33,9 +33,8 @@ set -e -x
 		-e "s/strcmp/yaffs_strcmp/g" \
 		-e "s/strncmp/yaffs_strncmp/g"\
 		-e "s/loff_t/Y_LOFF_T/g" \
+		../$i \
 		 >$i
-
-		chmod 0444 $i
 	done
 elif [ "$1" = "clean" ] ; then 
 	for i in $YAFFS_COMMON_SOURCES ; do


### PR DESCRIPTION
In line with https://github.com/kempniu/yafut/pull/29, this small change:
 - allows `handle_common.sh` to operate without incident with a broader variety of `sed` implementations.
 - makes it possible for subsequent runs of `handle_common.sh` to succeed, when used as it is by `yafut`’s cmake configure phase.